### PR TITLE
Feature: more thorough test coverage

### DIFF
--- a/.changeset/empty-bulldogs-knock.md
+++ b/.changeset/empty-bulldogs-knock.md
@@ -1,0 +1,5 @@
+---
+"oamerge": patch
+---
+
+Handle inputs better e.g. "input" versus "inputs".

--- a/.changeset/new-horses-fetch.md
+++ b/.changeset/new-horses-fetch.md
@@ -1,0 +1,5 @@
+---
+"oamerge": patch
+---
+
+Make sure multiple path renames are handled correctly across inputs.

--- a/.changeset/serious-crabs-attack.md
+++ b/.changeset/serious-crabs-attack.md
@@ -1,0 +1,5 @@
+---
+"oamerge": patch
+---
+
+Add default loaders for JavaScript and JSON. Later loaders will override them.

--- a/.changeset/tender-moles-argue.md
+++ b/.changeset/tender-moles-argue.md
@@ -1,0 +1,5 @@
+---
+"@oamerge/generator-routes": patch
+---
+
+Export default and not require options as per documentation.

--- a/examples/simple-api/api-1/paths/hello/[name]/_.@.js
+++ b/examples/simple-api/api-1/paths/hello/[name]/_.@.js
@@ -1,0 +1,1 @@
+export const $path = '/hello/{name}'

--- a/examples/simple-api/api-1/paths/hello/[name]/get.@.js
+++ b/examples/simple-api/api-1/paths/hello/[name]/get.@.js
@@ -1,0 +1,7 @@
+export const summary = 'Says Hello'
+export const description = 'Simple example using the NodeJS http request/response model.'
+export default async (request, response) => {
+	response.statusCode = 200
+	response.setHeader('Content-Type', 'text/plain')
+	response.end('Hello World!')
+}

--- a/examples/simple-api/api-1/paths/hello/[name]/patch.@.js
+++ b/examples/simple-api/api-1/paths/hello/[name]/patch.@.js
@@ -1,0 +1,7 @@
+export const summary = 'Update Person'
+export const description = 'Update sparse properties of a person.'
+export default async (request, response) => {
+	response.statusCode = 200
+	response.setHeader('Content-Type', 'text/plain')
+	response.end('Hello World!')
+}

--- a/examples/simple-api/api-2/paths/hello/[name]/_.@.js
+++ b/examples/simple-api/api-2/paths/hello/[name]/_.@.js
@@ -1,0 +1,1 @@
+export const $path = '/hello/{name}'

--- a/examples/simple-api/api-2/paths/hello/[name]/put.@.js
+++ b/examples/simple-api/api-2/paths/hello/[name]/put.@.js
@@ -1,0 +1,7 @@
+export const summary = 'Update Person'
+export const description = 'Replace all person properties.'
+export default async (request, response) => {
+	response.statusCode = 200
+	response.setHeader('Content-Type', 'text/plain')
+	response.end('Hello World!')
+}

--- a/examples/simple-api/api-3/paths/hello/[name]/_.@.js
+++ b/examples/simple-api/api-3/paths/hello/[name]/_.@.js
@@ -1,0 +1,1 @@
+export const $path = '/hello/{name}'

--- a/examples/simple-api/api-3/paths/hello/[name]/get.@.js
+++ b/examples/simple-api/api-3/paths/hello/[name]/get.@.js
@@ -1,0 +1,7 @@
+export const summary = 'Says Hello (Overwrite)'
+export const description = 'Say hello in a different way!'
+export default async (request, response) => {
+	response.statusCode = 200
+	response.setHeader('Content-Type', 'text/plain')
+	response.end('Hello World!')
+}

--- a/examples/simple-api/api-3/paths/hello/[name]/post.@.js
+++ b/examples/simple-api/api-3/paths/hello/[name]/post.@.js
@@ -1,0 +1,7 @@
+export const summary = 'Create Person'
+export const description = 'Create a new person if the name does not exist already.'
+export default async (request, response) => {
+	response.statusCode = 200
+	response.setHeader('Content-Type', 'text/plain')
+	response.end('Hello World!')
+}

--- a/examples/simple-api/build/routes.js
+++ b/examples/simple-api/build/routes.js
@@ -1,0 +1,27 @@
+import handler_0 from '../api-3/paths/hello/[name]/get.@.js'
+import handler_1 from '../api-1/paths/hello/[name]/patch.@.js'
+import handler_2 from '../api-3/paths/hello/[name]/post.@.js'
+import handler_3 from '../api-2/paths/hello/[name]/put.@.js'
+
+export const routes = [
+	{
+		path: '/hello/{name}',
+		method: 'get',
+		handler: handler_0,
+	},
+	{
+		path: '/hello/{name}',
+		method: 'patch',
+		handler: handler_1,
+	},
+	{
+		path: '/hello/{name}',
+		method: 'post',
+		handler: handler_2,
+	},
+	{
+		path: '/hello/{name}',
+		method: 'put',
+		handler: handler_3,
+	},
+]

--- a/examples/simple-api/oamerge.config.js
+++ b/examples/simple-api/oamerge.config.js
@@ -1,0 +1,13 @@
+import routes from '../../packages/generator-routes/dist/generator.js'
+
+export default {
+	inputs: [
+		'./api-1',
+		'./api-2',
+		'./api-3',
+	],
+	output: './build',
+	generators: [
+		routes(),
+	],
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:lint": "eslint 'packages/*/src/**/*.js' 'packages/*/rollup.config.js' 'packages/oamerge/cli.js'",
     "test:unit": "uvu packages '.test.js$'",
     "build": "npm run build -ws --if-present",
+    "postbuild": "node packages/oamerge/dist/cli.js --verbose --cwd examples/simple-api --config oamerge.config.js",
     "release": "npm run build && changeset publish"
   },
   "repository": {

--- a/packages/generator-routes/src/generator.js
+++ b/packages/generator-routes/src/generator.js
@@ -3,8 +3,8 @@ import { dirname, join } from 'node:path'
 
 import { treeToJavascript } from './tree-to-javascript.js'
 
-export const generator = ({ output: outputDirFilepath }) => async ({ cwd, output: outputDir, TREE: { inputs } }) => {
-	const outputFullFilepath = join(outputDir, outputDirFilepath)
+export default opts => async ({ cwd, output: outputDir, TREE: { inputs } }) => {
+	const outputFullFilepath = join(outputDir, opts?.output || 'routes.js')
 	await mkdir(dirname(outputFullFilepath), { recursive: true })
 	const code = treeToJavascript({ cwd, outputDir: dirname(outputFullFilepath), inputs })
 	await writeFile(outputFullFilepath, code, 'utf8')

--- a/packages/generator-routes/src/tree-to-javascript.js
+++ b/packages/generator-routes/src/tree-to-javascript.js
@@ -24,9 +24,11 @@ const parseReference = string => {
 	return segments
 }
 
+const jsString = string => string.includes("'") ? JSON.stringify(string) : `'${string}'`
+
 const makeRoute = ({ path, method, importsIndex }) => `\t{
-\t\tpath: ${JSON.stringify(path)},
-\t\tmethod: ${JSON.stringify(method)},
+\t\tpath: ${jsString(path)},
+\t\tmethod: ${jsString(method)},
 \t\thandler: handler_${importsIndex},
 \t},`
 
@@ -147,7 +149,7 @@ export const treeToJavascript = ({ cwd, outputDir, inputs }) => {
 		}
 	}
 
-	let importsLines = imports.map((filepath, index) => `import handler_${index} from ${JSON.stringify(relative(buildPath, resolve(buildPath, join(cwd, filepath))))}`)
+	let importsLines = imports.map((filepath, index) => `import handler_${index} from ${jsString(relative(buildPath, resolve(buildPath, join(cwd, filepath))))}`)
 	importsLines = importsLines.length
 		? `${importsLines.join('\n')}\n\n`
 		: ''

--- a/packages/generator-routes/tests/_a-simple-example-test.md
+++ b/packages/generator-routes/tests/_a-simple-example-test.md
@@ -41,12 +41,12 @@ The `#expected` block is compared to the generated output by string strict equal
 is here is *exactly* what will be asserted as equal. (In other words, no comments here.)
 
 ```js #expected
-import handler_0 from "../folder1/paths/hello/world/get.@.js"
+import handler_0 from '../folder1/paths/hello/world/get.@.js'
 
 export const routes = [
 	{
-		path: "/v1/hello/world",
-		method: "get",
+		path: '/v1/hello/world',
+		method: 'get',
 		handler: handler_0,
 	},
 ]

--- a/packages/generator-routes/tests/file-path-override.md
+++ b/packages/generator-routes/tests/file-path-override.md
@@ -30,12 +30,12 @@ return {
 ```
 
 ```js #expected
-import handler_0 from "../folder1/paths/hello/get.@.js"
+import handler_0 from '../folder1/paths/hello/get.@.js'
 
 export const routes = [
 	{
-		path: "/v1/not/hello",
-		method: "get",
+		path: '/v1/not/hello',
+		method: 'get',
 		handler: handler_0,
 	},
 ]

--- a/packages/generator-routes/tests/handler-in-different-file.md
+++ b/packages/generator-routes/tests/handler-in-different-file.md
@@ -31,12 +31,12 @@ return {
 Because the underscore file is more specific, that handler is used instead of the first.
 
 ```js #expected
-import handler_0 from "../folder1/paths/hello/get/_.@.js"
+import handler_0 from '../folder1/paths/hello/get/_.@.js'
 
 export const routes = [
 	{
-		path: "/v1/hello",
-		method: "get",
+		path: '/v1/hello',
+		method: 'get',
 		handler: handler_0,
 	},
 ]

--- a/packages/generator-routes/tests/multiple-path-rewrites.md
+++ b/packages/generator-routes/tests/multiple-path-rewrites.md
@@ -1,0 +1,70 @@
+If multiple `inputs` have a `$path` override, they will all be handled
+together as a group correctly.
+
+```js #config
+return {
+	cwd: '/root',
+	outputDir: './build',
+	inputs: [
+		{
+			dir: 'folder1',
+			ext: '@',
+			api: '/v1',
+			files: {
+				'paths/hello/_.@.js': {
+					key: [ 'paths', 'hello', '_' ],
+					exports: {
+						// The unescaped path string.
+						$path: '/not/hello'
+					},
+				},
+				'paths/hello/get.@.js': {
+					key: [ 'paths', 'hello', 'get' ],
+					exports: {
+						default: _ => _,
+					},
+				},
+			},
+		},
+		{
+			dir: 'folder2',
+			ext: '@',
+			api: '/v1',
+			files: {
+				'paths/hello/_.@.js': {
+					key: [ 'paths', 'hello', '_' ],
+					exports: {
+						// The unescaped path string.
+						$path: '/not/hello'
+					},
+				},
+				'paths/hello/patch.@.js': {
+					key: [ 'paths', 'hello', 'patch' ],
+					exports: {
+						default: _ => _,
+					},
+				},
+			},
+		},
+	],
+}
+```
+
+```js #expected
+import handler_0 from '../folder1/paths/hello/get.@.js'
+import handler_1 from '../folder2/paths/hello/patch.@.js'
+
+export const routes = [
+	{
+		path: '/v1/not/hello',
+		method: 'get',
+		handler: handler_0,
+	},
+	{
+		path: '/v1/not/hello',
+		method: 'patch',
+		handler: handler_1,
+	},
+]
+
+```

--- a/packages/generator-routes/tests/references-resolve-to-handlers.md
+++ b/packages/generator-routes/tests/references-resolve-to-handlers.md
@@ -43,29 +43,29 @@ return {
 The `alias` inherits all methods, but its own methods will overwrite referenced ones.
 
 ```js #expected
-import handler_0 from "../folder1/paths/hello/get.@.js"
-import handler_1 from "../folder1/paths/alias/patch.@.js"
-import handler_2 from "../folder1/paths/hello/patch.@.js"
+import handler_0 from '../folder1/paths/hello/get.@.js'
+import handler_1 from '../folder1/paths/alias/patch.@.js'
+import handler_2 from '../folder1/paths/hello/patch.@.js'
 
 export const routes = [
 	{
-		path: "/v1/alias",
-		method: "get",
+		path: '/v1/alias',
+		method: 'get',
 		handler: handler_0,
 	},
 	{
-		path: "/v1/alias",
-		method: "patch",
+		path: '/v1/alias',
+		method: 'patch',
 		handler: handler_1,
 	},
 	{
-		path: "/v1/hello",
-		method: "get",
+		path: '/v1/hello',
+		method: 'get',
 		handler: handler_0,
 	},
 	{
-		path: "/v1/hello",
-		method: "patch",
+		path: '/v1/hello',
+		method: 'patch',
 		handler: handler_2,
 	},
 ]

--- a/packages/oamerge/src/lib/execute-loaders.js
+++ b/packages/oamerge/src/lib/execute-loaders.js
@@ -1,9 +1,32 @@
-import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { extname, join } from 'node:path'
+
+const javascriptLoader = async ({ cwd, inputDirectory, filepath, ext }) => {
+	if (ext === 'js') try {
+		return await import(join(cwd, inputDirectory, filepath))
+	} catch (error) {
+		console.warn(`Default JavaScript loader could not load file [dir=${inputDirectory}, file=${filepath}]:`, error)
+	}
+}
+
+const jsonLoader = async ({ cwd, inputDirectory, filepath, ext }) => {
+	if (ext === 'json') try {
+		return JSON.parse(await readFile(join(cwd, inputDirectory, filepath), 'utf8'))
+	} catch (error) {
+		console.warn(`Default JSON loader could not load file [dir=${inputDirectory}, file=${filepath}]:`, error)
+	}
+}
+
+const defaultLoaders = [
+	javascriptLoader,
+	jsonLoader,
+]
 
 export const executeLoaders = async (cwd, inputDirectory, filepath, loaders) => {
 	let atLeastOneLoader
-	const results = await Promise.all(loaders.map(
-		load => load({ cwd, inputDirectory, filepath })
+	const ext = extname(filepath).replace(/^\./, '')
+	const results = await Promise.all([ ...defaultLoaders, ...(loaders || []) ].filter(Boolean).map(
+		load => load({ cwd, inputDirectory, filepath, ext })
 			.then(out => {
 				atLeastOneLoader = true
 				return out

--- a/packages/oamerge/src/lib/load-all-inputs.js
+++ b/packages/oamerge/src/lib/load-all-inputs.js
@@ -11,4 +11,6 @@ const loadInputFiles = (cwd, loaders) => async ({ dir, ext }, inputIndex) => {
 	))
 }
 
-export const loadAllInputs = async (cwd, inputs, loaders) => Promise.all(inputs.map(loadInputFiles(cwd, loaders)))
+export const loadAllInputs = async (cwd, inputs, loaders) => Promise
+	.all(inputs.map(loadInputFiles(cwd, loaders)))
+	.then(listOfLists => listOfLists.flat())

--- a/packages/oamerge/src/oamerge.js
+++ b/packages/oamerge/src/oamerge.js
@@ -10,13 +10,14 @@ import { executeLoaders } from './lib/execute-loaders.js'
 import { createTree, updateTreeFile } from './lib/mutate-tree.js'
 import { executeGenerators } from './lib/execute-generators.js'
 
-export const oamerge = async ({ inputs, output, generators, loaders, cwd, watch }) => {
+export const oamerge = async ({ input, inputs, output, generators, loaders, cwd, watch }) => {
 	const absoluteResolver = dir => isAbsolute(dir) ? dir : resolve(cwd, dir)
 	if (output) output = absoluteResolver(output)
 	await mkdir(output, { recursive: true })
 
-	if (inputs) inputs = normalizeInputs(inputs)
-	for (const input of inputs) if (input.dir) input.dir = absoluteResolver(input.dir)
+	inputs = normalizeInputs([ input, inputs ].filter(Boolean).flat())
+	if (!inputs.length) console.error('No inputs detected!')
+	console.debug('Normalized inputs:\n' + inputs.map(i => `  dir=${i.dir}; ext=${i.ext}; api=${i.api}`).join('\n'))
 
 	if (loaders?.length) loaders = await importPlugins('Loader', loaders, cwd)
 	if (generators?.length) generators = await importPlugins('Generator', generators, cwd)


### PR DESCRIPTION
I added the start of an overall test framework that I'll expand on later. It is a set of examples, which also double as testing scenarios which use the `oamerge` CLI (post-build) and one or more of the internally managed packages e.g. `@oamerge/generator-routes` (and eventually others).

My plan here is to set up and document multiple examples in code and assert the build output, and add it in such a way that the structure of it is easy enough to follow that other people can use that as a basis for creating new minimal-reproduction scenarios when issues are found.