### PR TITLE
feature: export security elements

### DIFF
--- a/.changeset/olive-avocados-roll.md
+++ b/.changeset/olive-avocados-roll.md
@@ -1,0 +1,5 @@
+---
+"@oamerge/generator-routes": patch
+---
+
+Optionally export security exports with routes.

--- a/examples/routes-generator-with-security/README.md
+++ b/examples/routes-generator-with-security/README.md
@@ -1,0 +1,3 @@
+# [OA Merge](../../) > [Examples](../) > Routes Generator Demo, with Security
+
+This set of examples shows security exports using `@oamerge/generator-routes`.

--- a/examples/routes-generator-with-security/api/paths/hello/get.@.js
+++ b/examples/routes-generator-with-security/api/paths/hello/get.@.js
@@ -1,0 +1,9 @@
+export const summary = 'Says Hello, Securely'
+export const security = [
+	{ api_key: [] },
+]
+export default async (request, response) => {
+	response.statusCode = 200
+	response.setHeader('Content-Type', 'text/plain')
+	response.end('Hello World!')
+}

--- a/examples/routes-generator-with-security/expected-build/routes.js
+++ b/examples/routes-generator-with-security/expected-build/routes.js
@@ -1,0 +1,10 @@
+import handler_0, { security as security_0 } from '../api/paths/hello/get.@.js'
+
+export const routes = [
+	{
+		path: '/hello',
+		method: 'get',
+		handler: handler_0,
+		security: security_0,
+	},
+]

--- a/examples/routes-generator-with-security/oamerge.config.js
+++ b/examples/routes-generator-with-security/oamerge.config.js
@@ -1,0 +1,9 @@
+import routes from '../../packages/generator-routes/src/generator.js'
+
+export default {
+	input: './api',
+	output: './build',
+	generators: [
+		routes({ security: true }),
+	],
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:examples": "npm run test:examples:build && npm run test:examples:test",
     "test:examples:build": "for d in examples/*/; do node packages/oamerge/src/cli.js --verbose --cwd $d --config oamerge.config.js ; done",
     "test:examples:test": "node examples/assert-builds.js",
-    "build": "npm run build -ws --if-present",
+    "demo": "node packages/oamerge/src/cli.js --verbose --cwd $DIR --config oamerge.config.js",
+    "build": "npm run build -ws --if-present -- --failAfterWarnings",
     "release": "npm run build && changeset publish"
   },
   "repository": {

--- a/packages/generator-routes/src/generator.js
+++ b/packages/generator-routes/src/generator.js
@@ -6,6 +6,6 @@ import { treeToJavascript } from './tree-to-javascript.js'
 export default opts => async ({ cwd, output: outputDir, TREE: { inputs } }) => {
 	const outputFullFilepath = join(outputDir, opts?.output || 'routes.js')
 	await mkdir(dirname(outputFullFilepath), { recursive: true })
-	const code = treeToJavascript({ cwd, outputDir: dirname(outputFullFilepath), inputs })
+	const code = treeToJavascript({ cwd, outputDir: dirname(outputFullFilepath), inputs, includeSecurity: !!opts?.security })
 	await writeFile(outputFullFilepath, code, 'utf8')
 }

--- a/packages/generator-routes/tests/include-security-exports.md
+++ b/packages/generator-routes/tests/include-security-exports.md
@@ -1,0 +1,43 @@
+If you pass in `security: true` in the generator options, you get the security exports included.
+
+```js #config
+return {
+	cwd: '/root',
+	outputDir: './build',
+	includeSecurity: true,
+	inputs: [
+		{
+			dir: 'folder1',
+			ext: '@',
+			api: '/v1',
+			files: {
+				'paths/hello/get.@.js': {
+					key: [ 'paths', 'hello', 'get' ],
+					exports: {
+						default: _ => _,
+						// It doesn't matter what is exported, just that
+						// there be an export.
+						security: [],
+					},
+				},
+			},
+		},
+	],
+}
+```
+
+The output renames the exports, to prevent collisions:
+
+```js #expected
+import handler_0, { security as security_0 } from '../folder1/paths/hello/get.@.js'
+
+export const routes = [
+	{
+		path: '/v1/hello',
+		method: 'get',
+		handler: handler_0,
+		security: security_0,
+	},
+]
+
+```


### PR DESCRIPTION
Pass in the routes generator option `security: true` and it'll output something more like this:

```js
import handler_0, { security as security_0 } from '../folder1/paths/hello/get.@.js'
export const routes = [
	{
		path: '/v1/hello',
		method: 'get',
		handler: handler_0,
		security: security_0,
	},
]
```